### PR TITLE
認証する際にChallegeをPort80, 443と切り替えられるように対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ letsencrypt:
   cron_user: root
   cron_file_path: /etc/cron.d/itamae-letsencrypt
   cron_configuration: true
+  challenge_type: 'http-01' # port80 is http-01, port443 is tls-sni-01 
   domains:
     - test.example.com
     - test2.example.com
 ```
+
 
 
 ## Contributing

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -3,7 +3,8 @@ node.reverse_merge!(
     certbot_auto_path: '/usr/bin/certbot-auto',
     cron_user: 'root',
     cron_file_path: '/etc/cron.d/itamae-letsencrypt',
-    cron_configuration: true
+    cron_configuration: true,
+    challenge_type: 'http-01'
   }
 )
 
@@ -22,7 +23,7 @@ end
 # get each domain certificate
 node[:letsencrypt][:domains].each do |domain|
   execute "get #{domain} certificate" do
-    command "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n"
+    command "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --standalone-supported-challenges #{node[:letsencrypt][:challenge_type]}"
   end
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/version.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/version.rb
@@ -2,7 +2,7 @@ module Itamae
   module Plugin
     module Recipe
       module Letsencrypt
-        VERSION = "0.1.0"
+        VERSION = "0.2.0"
       end
     end
   end


### PR DESCRIPTION
## 目的
証明書を発行する際にportをあけておく必要があるが、80, 443と任意のportを選べるように設定しました

## TODO
- [x] portの設定
- [x] README.mdの変更