### PR TITLE
Amazon linux and webroot authenticator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Itamae::Plugin::Recipe::Letsencrypt
 
-This gem is [itamae](https://github.com/ryotarai/itamae) plugin.  
+This gem is [itamae](https://github.com/ryotarai/itamae) plugin.
 Get certificate of domain from [Let's Encrypt](https://letsencrypt.org/)
 
 ## Installation
@@ -22,7 +22,7 @@ Or install it yourself as:
 ## Support
 - Debian GNU/Linux 8 (jessie)
 
-I have not confirmed it in other environments yet  
+I have not confirmed it in other environments yet
 I will check in turn
 
 ## Usage
@@ -44,12 +44,14 @@ letsencrypt:
   cron_user: root
   cron_file_path: /etc/cron.d/itamae-letsencrypt
   cron_configuration: true
-  challenge_type: 'http-01' # port80 is http-01, port443 is tls-sni-01 
+  challenge_type: 'http-01' # port80 is http-01, port443 is tls-sni-01
   domains:
     - test.example.com
     - test2.example.com
+  authenticator: standalone # standalone, webroot
+  webroot_path: /var/www/example
 ```
- 
+
 **Process of the port selected by `challenge_type` needs to be stopped**
 
 
@@ -65,4 +67,3 @@ letsencrypt:
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ letsencrypt:
     - test2.example.com
   authenticator: standalone # standalone, webroot
   webroot_path: /var/www/example
+  debug_mode: false
 ```
 
 **Process of the port selected by `challenge_type` needs to be stopped**

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -8,6 +8,13 @@ execute 'set cron file' do
   command "echo '#{cron_text}' > #{node[:letsencrypt][:cron_file_path]}"
 end
 
-service "cron" do
+service_name = case node[:platform]
+              when 'amazon'
+                'crond'
+              else
+                'cron'
+              end
+
+service service_name do
   action :start
 end

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -4,8 +4,8 @@ cron_text = <<-EOS
 0 0 1 * * #{node[:letsencrypt][:cron_user]} #{node[:letsencrypt][:certbot_auto_path]} renew
 EOS
 
-execute 'set cron file' do
-  command "echo '#{cron_text}' > #{node[:letsencrypt][:cron_file_path]}"
+file node[:letsencrypt][:cron_file_path] do
+  content cron_text
 end
 
 service_name = case node[:platform]

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -23,7 +23,7 @@ end
 # get each domain certificate
 node[:letsencrypt][:domains].each do |domain|
   execute "get #{domain} certificate" do
-    command "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --standalone-supported-challenges #{node[:letsencrypt][:challenge_type]}"
+    command "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --preferred-challenges #{node[:letsencrypt][:challenge_type]}"
   end
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -17,13 +17,17 @@ execute 'change certbot-auto permission' do
 end
 
 execute 'install dependency package' do
-  command "#{node[:letsencrypt][:certbot_auto_path]} -n --os-packages-only"
+  cmd = "#{node[:letsencrypt][:certbot_auto_path]} -n --os-packages-only"
+  cmd << ' --debug' if node[:platform] == 'amazon'
+  command cmd
 end
 
 # get each domain certificate
 node[:letsencrypt][:domains].each do |domain|
   execute "get #{domain} certificate" do
-    command "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --preferred-challenges #{node[:letsencrypt][:challenge_type]}"
+    cmd "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --preferred-challenges #{node[:letsencrypt][:challenge_type]}"
+    cmd << ' --debug' if node[:platform] == 'amazon'
+    command cmd
   end
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -25,9 +25,19 @@ end
 # get each domain certificate
 node[:letsencrypt][:domains].each do |domain|
   execute "get #{domain} certificate" do
-    cmd "#{node[:letsencrypt][:certbot_auto_path]} certonly --agree-tos -d #{domain} -m #{node[:letsencrypt][:email]} -a standalone --keep -n --preferred-challenges #{node[:letsencrypt][:challenge_type]}"
-    cmd << ' --debug' if node[:platform] == 'amazon'
-    command cmd
+    cmd = [
+      node[:letsencrypt][:certbot_auto_path],
+      'certonly',
+      '--agree-tos',
+      "-d #{domain}",
+      "-m #{node[:letsencrypt][:email]}",
+      "-a standalone",
+      '--keep',
+      '-n',
+      "--preferred-challenges #{node[:letsencrypt][:challenge_type]}",
+    ]
+    cmd << '--debug' if node[:platform] == 'amazon'
+    command cmd.join(' ')
   end
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -4,7 +4,8 @@ node.reverse_merge!(
     cron_user: 'root',
     cron_file_path: '/etc/cron.d/itamae-letsencrypt',
     cron_configuration: true,
-    challenge_type: 'http-01'
+    challenge_type: 'http-01',
+    authenticator: 'standalone',
   }
 )
 
@@ -31,11 +32,12 @@ node[:letsencrypt][:domains].each do |domain|
       '--agree-tos',
       "-d #{domain}",
       "-m #{node[:letsencrypt][:email]}",
-      "-a standalone",
+      "-a #{node[:letsencrypt][:authenticator]}",
       '--keep',
       '-n',
       "--preferred-challenges #{node[:letsencrypt][:challenge_type]}",
     ]
+    cmd << "-w #{node[:letsencrypt][:webroot_path]}" if node[:letsencrypt][:webroot_path]
     cmd << '--debug' if node[:platform] == 'amazon'
     command cmd.join(' ')
   end

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -6,6 +6,7 @@ node.reverse_merge!(
     cron_configuration: true,
     challenge_type: 'http-01',
     authenticator: 'standalone',
+    debug_mode: false,
   }
 )
 
@@ -21,7 +22,7 @@ end
 
 execute 'install dependency package' do
   cmd = "#{node[:letsencrypt][:certbot_auto_path]} -n --os-packages-only"
-  cmd << ' --debug' if node[:platform] == 'amazon'
+  cmd << ' --debug' if node[:letsencrypt][:debug_mode]
   command cmd
   not_if "test -n \"$(#{cmd} --dry-run | grep 'OS packages installed.')\""
 end
@@ -41,7 +42,7 @@ node[:letsencrypt][:domains].each do |domain|
       "--preferred-challenges #{node[:letsencrypt][:challenge_type]}",
     ]
     cmd << "-w #{node[:letsencrypt][:webroot_path]}" if node[:letsencrypt][:webroot_path]
-    cmd << '--debug' if node[:platform] == 'amazon'
+    cmd << '--debug' if node[:letsencrypt][:debug_mode]
     command cmd.join(' ')
     not_if "test -d /etc/letsencrypt/live/#{domain}"
   end


### PR DESCRIPTION
Included changes
- Fix deprecated warning --standalone_supported_challenges
- Amazon Linux support
  > ERROR :         stdout | FATAL: Amazon Linux support is very experimental at present...
ERROR :         stdout | if you would like to work on improving it, please ensure you have backups
ERROR :         stdout | and then run this script again with the --debug flag!
ERROR :         Command `/usr/bin/certbot-auto -n --os-packages-only` failed. (exit status: 1)
ERROR :       execute[install dependency package] Failed.
- webroot authenticator support
- only execute resources when needed