### PR TITLE
Update Certbot installation and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- Updated Certbot installation
+- Revised certificates getting/updating process
+
 ## v0.2.1 - 2017/01/10
 - Support Amazon Linux
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,66 @@
 # Itamae::Plugin::Recipe::Letsencrypt
 
-This gem is [itamae](https://github.com/ryotarai/itamae) plugin.
-Get certificate of domain from [Let's Encrypt](https://letsencrypt.org/)
+This gem is an [Itamae][] plugin for getting the [Let's Encrypt][le] certificates with [Certbot][].
+
+[Certbot]: https://certbot.eff.org/
+[Itamae]: https://github.com/ryotarai/itamae
+[le]: https://letsencrypt.org/
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 gem 'itamae-plugin-recipe-letsencrypt'
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install itamae-plugin-recipe-letsencrypt
+And then execute `bundle`.
+Or install it yourself as `gem install itamae-plugin-recipe-letsencrypt`.
 
 ## Support
-- Debian GNU/Linux 8 (jessie)
 
-I have not confirmed it in other environments yet
-I will check in turn
+- [Debian GNU/Linux 10 (buster)][buster]
+
+[buster]: https://www.debian.org/releases/buster/
+
+Contributions are welcome for other platforms.
 
 ## Usage
 
 ### Recipe
 
-```rb
+```ruby
 include_recipe "letsencrypt::get"
 ```
 
 ### Node
-`itamae -y node.yml`
 
 ```yaml
 # node.yml
 letsencrypt:
-  certbot_auto_path: /usr/bin/certbot-auto
-  email: test@example.com
-  cron_user: root
-  cron_file_path: /etc/cron.d/itamae-letsencrypt
-  cron_configuration: true
-  challenge_type: 'http-01' # port80 is http-01, port443 is tls-sni-01
   domains:
     - test.example.com
     - test2.example.com
-  authenticator: standalone # standalone, webroot
+  email: test@example.com
   webroot_path: /var/www/example
-  debug_mode: false
 ```
 
-**Process of the port selected by `challenge_type` needs to be stopped**
+```shell
+itamae -y node.yml
+```
 
+Other attributes are set to defaults as in `lib/itamae/plugin/recipe/letsencrypt/get.rb`.
+Note that process of the port selected by `challenge_type` needs to be stopped.
 
 ## Contributing
 
-1. Fork it ( https://github.com/hatappi/itamae-plugin-recipe-letsencrypt/fork )
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
+1. [Fork it][fork]
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
+[fork]: https://github.com/hatappi/itamae-plugin-recipe-letsencrypt/fork
 
 ## License
 

--- a/itamae-plugin-recipe-letsencrypt.gemspec
+++ b/itamae-plugin-recipe-letsencrypt.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "itamae-plugin-resource-snappy", "~> 0.1.0"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/itamae/plugin/recipe/letsencrypt/command.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/command.rb
@@ -1,0 +1,13 @@
+node.reverse_merge!(
+  letsencrypt: {
+    command: '/usr/bin/certbot',
+  }
+)
+
+node.validate! do
+  {
+    letsencrypt: {
+      command: string,
+    }
+  }
+end

--- a/lib/itamae/plugin/recipe/letsencrypt/command/default.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/command/default.rb
@@ -1,0 +1,13 @@
+node.reverse_merge!(
+  letsencrypt: {
+    command: '/usr/bin/certbot',
+  }
+)
+
+node.validate! do
+  {
+    letsencrypt: {
+      command: string,
+    }
+  }
+end

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -1,10 +1,11 @@
+include_recipe 'command'
+
 node.reverse_merge!(
   letsencrypt: {
     cron: {
       user: 'root',
       file_path: '/etc/cron.d/itamae-letsencrypt',
     },
-    command: '/usr/bin/certbot',
   }
 )
 
@@ -15,19 +16,14 @@ node.validate! do
         user: string,
         file_path: string,
       },
-      command: string,
     }
   }
 end
 
-cron_text = <<-EOS
-# DO NOT EDIT
-# BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt
-0 0 1 * * #{node[:letsencrypt][:cron][:user]} #{node[:letsencrypt][:command]} renew
-EOS
-
-file node[:letsencrypt][:cron][:file_path] do
-  content cron_text
+template node[:letsencrypt][:cron][:file_path] do
+  variables user: node[:letsencrypt][:cron][:user],
+            command: node[:letsencrypt][:command]
+  source 'templates/etc/cron.d/itamae-letsencrypt.erb'
 end
 
 service_name = case node[:platform]

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -31,11 +31,11 @@ file node[:letsencrypt][:cron][:file_path] do
 end
 
 service_name = case node[:platform]
-              when 'amazon'
-                'crond'
-              else
-                'cron'
-              end
+               when 'amazon'
+                 'crond'
+               else
+                 'cron'
+               end
 
 service service_name do
   action :start

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -8,6 +8,18 @@ node.reverse_merge!(
   }
 )
 
+node.validate! do
+  {
+    letsencrypt: {
+      cron: {
+        user: string,
+        file_path: string,
+      },
+      certbot_auto_path: string,
+    }
+  }
+end
+
 cron_text = <<-EOS
 # DO NOT EDIT
 # BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -4,7 +4,7 @@ node.reverse_merge!(
       user: 'root',
       file_path: '/etc/cron.d/itamae-letsencrypt',
     },
-    certbot_auto_path: '/usr/bin/certbot-auto',
+    command: '/usr/bin/certbot',
   }
 )
 
@@ -15,7 +15,7 @@ node.validate! do
         user: string,
         file_path: string,
       },
-      certbot_auto_path: string,
+      command: string,
     }
   }
 end
@@ -23,7 +23,7 @@ end
 cron_text = <<-EOS
 # DO NOT EDIT
 # BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt
-0 0 1 * * #{node[:letsencrypt][:cron][:user]} #{node[:letsencrypt][:certbot_auto_path]} renew
+0 0 1 * * #{node[:letsencrypt][:cron][:user]} #{node[:letsencrypt][:command]} renew
 EOS
 
 file node[:letsencrypt][:cron][:file_path] do

--- a/lib/itamae/plugin/recipe/letsencrypt/cron.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron.rb
@@ -1,10 +1,20 @@
+node.reverse_merge!(
+  letsencrypt: {
+    cron: {
+      user: 'root',
+      file_path: '/etc/cron.d/itamae-letsencrypt',
+    },
+    certbot_auto_path: '/usr/bin/certbot-auto',
+  }
+)
+
 cron_text = <<-EOS
 # DO NOT EDIT
 # BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt
-0 0 1 * * #{node[:letsencrypt][:cron_user]} #{node[:letsencrypt][:certbot_auto_path]} renew
+0 0 1 * * #{node[:letsencrypt][:cron][:user]} #{node[:letsencrypt][:certbot_auto_path]} renew
 EOS
 
-file node[:letsencrypt][:cron_file_path] do
+file node[:letsencrypt][:cron][:file_path] do
   content cron_text
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/cron/templates/etc/cron.d/itamae-letsencrypt.erb
+++ b/lib/itamae/plugin/recipe/letsencrypt/cron/templates/etc/cron.d/itamae-letsencrypt.erb
@@ -1,0 +1,3 @@
+# DO NOT EDIT
+# BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt
+0 0 1 * * <%= @user %> <%= @command %> renew

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -9,6 +9,21 @@ node.reverse_merge!(
   }
 )
 
+node.validate! do
+  {
+    letsencrypt: {
+      certbot_auto_path: string,
+      challenge_type: string,
+      authenticator: string,
+      debug_mode: boolean,
+
+      domains: array_of(string),
+      email: string,
+      webroot_path: optional(string),
+    }
+  }
+end
+
 execute 'download certbot-auto' do
   download = ["wget", "https://dl.eff.org/certbot-auto", "-O", node[:letsencrypt][:certbot_auto_path]].shelljoin
   command download

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -1,11 +1,12 @@
 require 'shellwords'
 
+include_recipe 'command'
+
 node.reverse_merge!(
   letsencrypt: {
     challenge_type: 'http-01',
     authenticator: 'standalone',
     debug_mode: false,
-    command: '/usr/bin/certbot',
     snappy_executable: '/snap/bin/certbot',
     live_dir: '/etc/letsencrypt/live',
   }
@@ -17,7 +18,6 @@ node.validate! do
       challenge_type: string,
       authenticator: string,
       debug_mode: boolean,
-      command: string,
       snappy_executable: string,
       live_dir: string,
 

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -3,9 +3,6 @@ require 'shellwords'
 node.reverse_merge!(
   letsencrypt: {
     certbot_auto_path: '/usr/bin/certbot-auto',
-    cron_user: 'root',
-    cron_file_path: '/etc/cron.d/itamae-letsencrypt',
-    cron_configuration: true,
     challenge_type: 'http-01',
     authenticator: 'standalone',
     debug_mode: false,
@@ -61,5 +58,3 @@ node[:letsencrypt][:domains].each do |domain|
     not_if exists
   end
 end
-
-include_recipe 'letsencrypt::cron' if node[:letsencrypt][:cron_configuration]

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 node.reverse_merge!(
   letsencrypt: {
     certbot_auto_path: '/usr/bin/certbot-auto',
@@ -11,20 +13,29 @@ node.reverse_merge!(
 )
 
 execute 'download certbot-auto' do
-  command "wget https://dl.eff.org/certbot-auto -O #{node[:letsencrypt][:certbot_auto_path]}"
-  not_if "test -f #{node[:letsencrypt][:certbot_auto_path]}"
+  download = ["wget", "https://dl.eff.org/certbot-auto", "-O", node[:letsencrypt][:certbot_auto_path]].shelljoin
+  command download
+
+  exists = ["test", "-f", node[:letsencrypt][:certbot_auto_path]].shelljoin
+  not_if exists
 end
 
 execute 'change certbot-auto permission' do
-  command "chmod a+x #{node[:letsencrypt][:certbot_auto_path]}"
-  not_if "test -x #{node[:letsencrypt][:certbot_auto_path]}"
+  make_executable = ["chmod", "a+x", node[:letsencrypt][:certbot_auto_path]].shelljoin
+  command make_executable
+
+  executable_exists = ["test", "-x", node[:letsencrypt][:certbot_auto_path]].shelljoin
+  not_if executable_exists
 end
 
 execute 'install dependency package' do
-  cmd = "#{node[:letsencrypt][:certbot_auto_path]} -n --os-packages-only"
-  cmd << ' --debug' if node[:letsencrypt][:debug_mode]
-  command cmd
-  not_if "test -n \"$(#{cmd} --dry-run | grep 'OS packages installed.')\""
+  cmd = [node[:letsencrypt][:certbot_auto_path], "-n", "--os-packages-only"].shelljoin
+  cmd << '--debug' if node[:letsencrypt][:debug_mode]
+  command cmd.shelljoin
+
+  dry_run = [*cmd, '--dry-run'].shelljoin
+  detect = ["grep", "OS packages installed."].shelljoin
+  not_if "test -n $(#{dry_run} | #{detect})"
 end
 
 # get each domain certificate
@@ -34,17 +45,20 @@ node[:letsencrypt][:domains].each do |domain|
       node[:letsencrypt][:certbot_auto_path],
       'certonly',
       '--agree-tos',
-      "-d #{domain}",
-      "-m #{node[:letsencrypt][:email]}",
-      "-a #{node[:letsencrypt][:authenticator]}",
+      "-d", domain,
+      "-m", node[:letsencrypt][:email],
+      "-a", node[:letsencrypt][:authenticator],
       '--keep',
       '-n',
-      "--preferred-challenges #{node[:letsencrypt][:challenge_type]}",
+      "--preferred-challenges", node[:letsencrypt][:challenge_type],
     ]
-    cmd << "-w #{node[:letsencrypt][:webroot_path]}" if node[:letsencrypt][:webroot_path]
+    cmd += ["-w", node[:letsencrypt][:webroot_path]] if node[:letsencrypt][:webroot_path]
     cmd << '--debug' if node[:letsencrypt][:debug_mode]
-    command cmd.join(' ')
-    not_if "test -d /etc/letsencrypt/live/#{domain}"
+    command cmd.shelljoin
+
+    dir = File.join("/etc/letsencrypt/live", domain)
+    exists = ["test", "-d", dir].shelljoin
+    not_if exists
   end
 end
 

--- a/lib/itamae/plugin/recipe/letsencrypt/get.rb
+++ b/lib/itamae/plugin/recipe/letsencrypt/get.rb
@@ -7,6 +7,7 @@ node.reverse_merge!(
     debug_mode: false,
     command: '/usr/bin/certbot',
     snappy_executable: '/snap/bin/certbot',
+    live_dir: '/etc/letsencrypt/live',
   }
 )
 
@@ -18,6 +19,7 @@ node.validate! do
       debug_mode: boolean,
       command: string,
       snappy_executable: string,
+      live_dir: string,
 
       domains: array_of(string),
       email: string,
@@ -54,7 +56,7 @@ node[:letsencrypt][:domains].each do |domain|
     cmd << '--debug' if node[:letsencrypt][:debug_mode]
     command cmd.shelljoin
 
-    dir = File.join("/etc/letsencrypt/live", domain)
+    dir = File.join(node[:letsencrypt][:live_dir], domain)
     exists = ["test", "-d", dir].shelljoin
     not_if exists
   end

--- a/lib/itamae/plugin/recipe/letsencrypt/templates/etc/cron.d/itamae-letsencrypt.erb
+++ b/lib/itamae/plugin/recipe/letsencrypt/templates/etc/cron.d/itamae-letsencrypt.erb
@@ -1,0 +1,3 @@
+# DO NOT EDIT
+# BECAUSE THIS CRON CREATE BY itamae-plugin-recipe-letsencrypt
+0 0 1 * * <%= @user %> <%= @command %> renew


### PR DESCRIPTION
Hello,

This updates Certbot installation, node attributes, and so on.
There is no `certbot-auto` command provided anymore, and the Snapcraft way is recommended.

I left cron recipe just in case, but it should be unnecessary for now since Certbot prepares them by itself.

Thanks,